### PR TITLE
Fix pawns

### DIFF
--- a/pawns/Dockerfile
+++ b/pawns/Dockerfile
@@ -1,8 +1,12 @@
-FROM iproyal/pawns-cli:0.33.0
+FROM alpine:latest
+
+RUN apk add --no-cache bash
+
+COPY --from=iproyal/pawns-cli:0.33.2 /pawns-cli /pawns-cli
 
 ENV email ""
 ENV password ""
-ENV device "HomeAssistant"
+ENV deviceName "HomeAssistant"
 ENV deviceId "homeassistant"
 
-ENTRYPOINT /pawns-cli "-accept-tos" "-email=$email" "-password=$password" "-device=$device" "-device-id=$deviceId"
+ENTRYPOINT ["/bin/sh", "-c", "/pawns-cli -accept-tos -email=$email -password=$password -device-name=$deviceName -device-id=$deviceId"]

--- a/pawns/config.yaml
+++ b/pawns/config.yaml
@@ -12,10 +12,10 @@ arch:
 options:
   email: ""
   password: ""
-  device: "HomeAssistant"
+  deviceName: "HomeAssistant"
   deviceId: "homeassistant"
 schema:
   email: str
   password: str
-  device: str
+  deviceName: str
   deviceId: str


### PR DESCRIPTION
Kept getting an issue where I couldn't start the addon due to "/bin/sh" not being found. So I rewrote the Dockerfile to explicitly install it and now it works. Also fixed the "-device-name" env.