### PR TITLE
feat: add device-name configuration option

### DIFF
--- a/traffmonetizer/Dockerfile
+++ b/traffmonetizer/Dockerfile
@@ -2,6 +2,6 @@ ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
 ENV token ""
-ENV device-name ""
+ENV device_name ""
 
-ENTRYPOINT ./Cli "start" "accept" "--token" "$token" "--device-name" "$device"
+ENTRYPOINT ./Cli "start" "accept" "--token" "$token" "--device-name" "$device_name"

--- a/traffmonetizer/config.yaml
+++ b/traffmonetizer/config.yaml
@@ -10,7 +10,7 @@ arch:
   - armv7
 options:
   token: ""
-  device-name: "HomeAssistant"
+  device_name: "HomeAssistant"
 schema:
   token: str
-  device-name: str
+  device_name: str

--- a/traffmonetizer/config.yaml
+++ b/traffmonetizer/config.yaml
@@ -10,5 +10,7 @@ arch:
   - armv7
 options:
   token: ""
+  device-name: "HomeAssistant"
 schema:
   token: str
+  device-name: str


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option `device_name` (defaults to "HomeAssistant") with validation so it can be set and required alongside existing credentials.
* **Chores**
  * Runtime/environment plumbing updated to use the new `device_name` variable so the configured device identifier is passed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->